### PR TITLE
docs: update for auto prompt splitting, CLI/env, and contributor workflow

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -29,6 +29,8 @@ Use `async with` to ensure Playwright resources close cleanly. Alternatively, ca
 
 Prompts are automatically decorated with a Markdown instruction when `settings.force_markdown_responses` is `True` (default). Disable via `COPILOT_FORCE_MARKDOWN=false` or the CLI flag `--no-force-markdown`.
 
+If a prompt exceeds `settings.max_prompt_chars`, it is split into multiple ordered parts. Non-final parts instruct Copilot to wait; the final part instructs Copilot to process all parts together. The final message is excluded from response scraping to reduce echoing.
+
 Responses are post-processed for cleaner Markdown when `settings.normalize_markdown` is `True`. Set `COPILOT_NORMALIZE_MARKDOWN=false` or use the CLI flag `--raw-markdown` to receive Copilot's unmodified output.
 
 ### Settings
@@ -58,6 +60,7 @@ Key fields:
 - `output_directory`
 - `force_markdown_responses`
 - `normalize_markdown`
+- `max_prompt_chars` (default `10000`)
 
 Secrets are sourced from (in order): environment variables, `.keyring.json` (fallback), then OS keyring. Non-secret config respects environment overrides (`M365_COPILOT_URL`, `BROWSER_HEADLESS`, etc.).
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,6 +11,7 @@ The CLI is the primary interface for automating Microsoft Copilot interactions. 
 | `--force-markdown/--no-force-markdown` | Toggle automatic Markdown instruction appended to prompts. | Config value |
 | `--normalize-markdown/--raw-markdown` | Post-process Copilot output or leave the raw response. | Config value |
 | `--log-level LEVEL` | Override logging verbosity (`DEBUG`, `INFO`, `WARNING`, `ERROR`). | `INFO` |
+| `--max-prompt-chars INTEGER` | Maximum characters per message before automatic splitting. | Config value |
 
 Global options must appear before the subcommand. Example:
 
@@ -37,7 +38,10 @@ ms-copilot auth  # uses env/keyring credentials
 
 ## Chat
 
-Send a prompt and print or save the response.
+Send a prompt and print or save the response. If a prompt exceeds the configured character limit, it is split into ordered parts:
+
+- Non-final parts include a header like `[Part 1/3]` and instruct Copilot to wait.
+- The final part uses `[Part 3/3 - Final]` and instructs Copilot to process all parts together.
 
 ```bash
 ms-copilot chat "Draft a short status update"
@@ -72,6 +76,7 @@ The CLI pulls additional configuration from environment variables or `.env`:
 - `OUTPUT_DIRECTORY`
 - `COPILOT_NORMALIZE_MARKDOWN`
 - `COPILOT_FORCE_MARKDOWN`
+- `COPILOT_MAX_PROMPT_CHARS`
 
 See the [Environment Reference](getting-started.md#configure-secrets) for full details.
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -14,11 +14,11 @@ Thank you for your interest in improving MS365 Copilot Automation! This guide ca
    - Use Python 3.10+ features as appropriate.
    - Aim for small, focused commits with clear messages.
    - Keep changes ASCII unless non-ASCII is already used.
-5. **Static Analysis (Recommended)**
-   - Run `ruff` or `flake8` if you have them configured.
-   - Optional: run `mypy` for type checking; annotations are gradually being introduced.
+5. **Static Analysis & Formatting**
+   - Run `make check` to lint (`ruff`), format-check, type-check (`mypy`), and run tests.
+   - Use `make lint-fix` and `make format` to auto-fix style issues.
 6. **Testing**
-   - Run unit tests: `PYTHONPATH=$(pwd) pytest`.
+   - Run unit tests: `make test`.
    - Opt-in live tests only when you have credentials: `M365_COPILOT_E2E=1 PYTHONPATH=$(pwd) pytest -m copilot_e2e`.
 7. **Commit & Push**
    - Include a summary of the change, referencing issues when appropriate.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ This quick guide walks you through installing dependencies, configuring credenti
 
 ```bash
 # Clone the repository
-git clone git@github.com:your-org/ms_copilot_automation.git
+git clone https://github.com/tomanizer/ms_copilot_automation.git
 cd ms_copilot_automation
 
 # Create and activate the virtual environment
@@ -36,6 +36,7 @@ python -m playwright install chromium
    # echo "M365_COPILOT_E2E=1" >> .env  # only if you plan to run live tests
    # echo "COPILOT_FORCE_MARKDOWN=false" >> .env  # disable automatic markdown instruction
    # echo "COPILOT_NORMALIZE_MARKDOWN=false" >> .env  # keep Copilot response unmodified
+   # echo "COPILOT_MAX_PROMPT_CHARS=10000" >> .env  # override default split threshold
    ```
 
 2. Store your password (and optional TOTP secret) securely:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -53,3 +53,9 @@ A: The controller launches Chromium. Modify `CopilotController.start()` to use `
 A: By default, the CLI writes to `./output`; override with `--output-dir` or the `OUTPUT_DIRECTORY` env var.
 
 Still stuck? Open an issue with logs and steps to reproduce.
+
+## Long Prompts Exceed Limits
+
+- If a prompt is very long, the tool automatically splits it into ordered parts and instructs Copilot to wait until the final part before responding.
+- Control the threshold with `COPILOT_MAX_PROMPT_CHARS` or `--max-prompt-chars`.
+- The final part is used as the `exclude_text` when scraping responses to avoid echo detection problems.


### PR DESCRIPTION
This PR updates documentation to reflect the current codebase:\n\n- CLI docs: add --max-prompt-chars and describe automatic prompt splitting\n- Getting Started: fix clone URL and document COPILOT_MAX_PROMPT_CHARS\n- API: mention settings.max_prompt_chars and chunking behavior\n- Troubleshooting: add section on long prompts and splitting\n- Contributing: reference make check/lint/format and test targets\n\nNo code changes. Improves clarity and aligns docs with recent features.