### PR TITLE
docs: Windows install guidance and firewall options (refs #4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,71 +1,40 @@
-# MS365 Copilot Automation Configuration
-# Copy this file to .env and fill in your actual values
-# Command: cp .env.example .env
-# IMPORTANT: Never commit .env to git (already in .gitignore)
+# MS365 Copilot Automation - Example .env
 
-# ============================================
-# Authentication (Required)
-# ============================================
+# --- Credentials ---
+# Required: your Microsoft 365 username (email)
+M365_USERNAME=
+# Optional: TOTP secret for MFA (Base32)
+# M365_OTP_SECRET=
 
-# Your Microsoft 365 account email
-M365_USERNAME=your-email@example.com
-
-# Password and MFA secret should be stored in keyring for security
-# To set password in keyring, run:
-#   python -c "import keyring; keyring.set_password('ms-copilot-automation', 'M365_PASSWORD', 'your-password')"
-# 
-# To set MFA/TOTP secret in keyring (if using MFA), run:
-#   python -c "import keyring; keyring.set_password('ms-copilot-automation', 'M365_OTP_SECRET', 'your-base32-secret')"
-#
-# Fallback: You can also create .keyring.json (not recommended, less secure):
-#   {"M365_PASSWORD": "your-password", "M365_OTP_SECRET": "your-totp-secret"}
-
-# Optional: Uncomment only if you need to override keyring (NOT RECOMMENDED for production)
-# M365_PASSWORD=your-password-here
-# M365_OTP_SECRET=your-totp-base32-secret
-
-# ============================================
-# Copilot Settings
-# ============================================
-
-# Microsoft Copilot URL (default: https://copilot.microsoft.com)
-M365_COPILOT_URL=https://copilot.microsoft.com
-
-# ============================================
-# Browser Settings
-# ============================================
-
-# Run browser in headless mode (true/false)
-# Set to false to see the browser window during automation
+# --- Runtime ---
+# Headless (true) or headed (false) browser
 BROWSER_HEADLESS=true
-
-# ============================================
-# Output Settings
-# ============================================
-
-# Directory for downloaded files and artifacts
+# Output directory for artifacts
 OUTPUT_DIRECTORY=./output
 
-# ============================================
-# Response Formatting
-# ============================================
+# --- Copilot Endpoint ---
+# Override Copilot URL if needed
+# M365_COPILOT_URL=https://copilot.microsoft.com
 
-# Automatically append Markdown formatting instructions to prompts (true/false)
+# --- Prompt Behavior ---
+# Append instruction to enforce Markdown responses
 COPILOT_FORCE_MARKDOWN=true
-
-# Post-process Copilot responses to normalize Markdown (true/false)
+# Normalize Copilot output into tidy Markdown
 COPILOT_NORMALIZE_MARKDOWN=true
+# Max characters per message before automatic splitting
+COPILOT_MAX_PROMPT_CHARS=10000
 
-# ============================================
-# Testing (Optional)
-# ============================================
+# --- Logging ---
+# DEBUG | INFO | WARNING | ERROR
+LOG_LEVEL=INFO
 
-# Enable live end-to-end tests (requires valid credentials)
-# M365_COPILOT_E2E=1
+# --- Playwright Browser Selection (Firewall-friendly) ---
+# Option 1: Point to an existing Chrome/Chromium executable to avoid downloads
+# macOS example:
+# BROWSER_EXECUTABLE_PATH=/Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+# Windows example:
+# BROWSER_EXECUTABLE_PATH=C:\Program Files\Google\Chrome\Application\chrome.exe
 
-# ============================================
-# Logging
-# ============================================
+# Option 2: Use a Chrome channel (e.g., chrome, chrome-beta) if available on your system
+# BROWSER_CHANNEL=chrome
 
-# Log level: DEBUG, INFO, WARNING, ERROR
-# LOG_LEVEL=INFO

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -85,3 +85,13 @@ See the [Environment Reference](getting-started.md#configure-secrets) for full d
 - Use `ms-copilot --headed ...` to watch the browser and debug selectors.
 - Set `PWDEBUG=1` to launch the Playwright Inspector for step-by-step tracing.
 - Delete `playwright/auth/user.json` if you need a fresh login.
+
+### Windows note
+
+- The CLI flags and behavior are identical on Windows.
+- Ensure your virtual environment is activated (PowerShell: `.\\venv\\Scripts\\Activate.ps1`, CMD: `venv\\Scripts\\activate.bat`).
+- Example (PowerShell):
+
+```powershell
+ms-copilot --log-level INFO --max-prompt-chars 10000 chat "Draft a weekly status update"
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,6 +25,32 @@ pip install -e .
 python -m playwright install chromium
 ```
 
+### Windows (PowerShell)
+
+```powershell
+# Create and activate venv
+python -m venv venv
+.\venv\Scripts\Activate.ps1
+
+# Install dependencies and browsers
+pip install -r requirements.txt
+pip install -e .
+python -m playwright install chromium
+```
+
+### Windows (CMD)
+
+```bat
+rem Create and activate venv
+py -m venv venv
+venv\Scripts\activate.bat
+
+rem Install dependencies and browsers
+pip install -r requirements.txt
+pip install -e .
+python -m playwright install chromium
+```
+
 ## Configure Secrets
 
 1. Create a `.env` file (ignored by git) to store your Copilot username and optional settings:
@@ -51,6 +77,22 @@ python -m playwright install chromium
    ```
 
    *Fallback:* if the OS keyring is unavailable, create `.keyring.json` with `M365_PASSWORD` and `M365_OTP_SECRET`. This file stays plaintext and should never be committed.
+
+### Environment variables on Windows
+
+- PowerShell:
+
+```powershell
+$env:LOG_LEVEL = "INFO"
+$env:COPILOT_MAX_PROMPT_CHARS = "10000"
+```
+
+- CMD:
+
+```bat
+set LOG_LEVEL=INFO
+set COPILOT_MAX_PROMPT_CHARS=10000
+```
 
 ## Authenticate
 
@@ -79,6 +121,22 @@ ms-copilot --output-dir output ask-with-file docs/report.docx \
 
 ```bash
 PYTHONPATH=$(pwd) pytest
+```
+
+On Windows:
+
+- PowerShell:
+
+```powershell
+$env:PYTHONPATH = (Get-Location).Path
+pytest -q
+```
+
+- CMD:
+
+```bat
+set PYTHONPATH=%CD%
+pytest -q
 ```
 
 (Optional) to exercise live Copilot flows, ensure the storage state or credentials are ready and run:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,6 +51,47 @@ pip install -e .
 python -m playwright install chromium
 ```
 
+## Behind a Firewall (Playwright alternatives)
+
+If `python -m playwright install chromium` is blocked by your firewall, you have two options:
+
+1. Configure Playwright to use an internal mirror (e.g., Artifactory) for browser binaries. See Playwright docs for `PLAYWRIGHT_BROWSERS_PATH` and enterprise mirrors. Coordinate with your IT team to expose the required artifacts internally.
+
+2. Point Playwright to an existing local Chrome/Chromium executable. Set one of the following and skip the browser install step:
+
+   - Environment variables:
+
+     - Unix/macOS:
+
+       ```bash
+       export BROWSER_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+       # or use a channel (e.g. chrome, chrome-beta)
+       export BROWSER_CHANNEL="chrome"
+       ```
+
+     - Windows PowerShell:
+
+       ```powershell
+       $env:BROWSER_EXECUTABLE_PATH = "C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe"
+       $env:BROWSER_CHANNEL = "chrome"
+       ```
+
+     - Windows CMD:
+
+       ```bat
+       set BROWSER_EXECUTABLE_PATH=C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe
+       set BROWSER_CHANNEL=chrome
+       ```
+
+   - Or via `.env`:
+
+     ```env
+     BROWSER_EXECUTABLE_PATH=/path/to/chrome
+     BROWSER_CHANNEL=chrome
+     ```
+
+The controller will pass these through to Playwright's `chromium.launch(...)` so you can run without downloading browser binaries.
+
 ## Configure Secrets
 
 1. Create a `.env` file (ignored by git) to store your Copilot username and optional settings:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,6 +54,11 @@ A: By default, the CLI writes to `./output`; override with `--output-dir` or the
 
 Still stuck? Open an issue with logs and steps to reproduce.
 
+## Windows-specific Notes
+
+- Prefer Windows Terminal with PowerShell for better compatibility.
+- If you hit platform-specific issues (path separators, activation), try Windows Subsystem for Linux (WSL) and follow the Unix-like instructions.
+
 ## Long Prompts Exceed Limits
 
 - If a prompt is very long, the tool automatically splits it into ordered parts and instructs Copilot to wait until the final part before responding.

--- a/src/automation/copilot_controller.py
+++ b/src/automation/copilot_controller.py
@@ -38,9 +38,13 @@ class CopilotController:
 
     async def start(self) -> None:
         self._playwright = await async_playwright().start()
-        self.browser = await self._playwright.chromium.launch(
-            headless=self.settings.browser_headless
-        )
+        launch_kwargs: dict[str, Any] = {"headless": self.settings.browser_headless}
+        # Allow custom executable or channel if set (useful behind firewalls)
+        if getattr(self.settings, "browser_executable_path", None):
+            launch_kwargs["executable_path"] = self.settings.browser_executable_path
+        if getattr(self.settings, "browser_channel", None):
+            launch_kwargs["channel"] = self.settings.browser_channel
+        self.browser = await self._playwright.chromium.launch(**launch_kwargs)
         storage = (
             str(self.settings.storage_state_path)
             if self.settings.storage_state_path.exists()

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -35,6 +35,8 @@ class Settings(BaseSettings):
     browser_headless: bool = Field(
         default=(os.getenv("BROWSER_HEADLESS", "true").lower() == "true")
     )
+    browser_executable_path: str | None = Field(default=os.getenv("BROWSER_EXECUTABLE_PATH"))
+    browser_channel: str | None = Field(default=os.getenv("BROWSER_CHANNEL"))
 
     # Prompt behaviour
     force_markdown_responses: bool = Field(


### PR DESCRIPTION
This PR adds Windows-friendly documentation and firewall-friendly options:\n\n- Getting Started: PowerShell and CMD sections; environment variable examples\n- Firewall: options to use enterprise mirrors or point to a local Chrome via BROWSER_EXECUTABLE_PATH/BROWSER_CHANNEL\n- CLI/Troubleshooting: Windows notes\n- .env.example: common settings including browser path/channel\n\nAlso adds code support to pass executable_path/channel to Playwright launch.\n\nRefs #4.